### PR TITLE
jsonrpc2: capture stacktrace in handler errors using try/catch patter…

### DIFF
--- a/src/jsonrpc2.erl
+++ b/src/jsonrpc2.erl
@@ -208,10 +208,10 @@ dispatch({Method, Params, Id}, HandlerFun) ->
         throw:{jsonrpc2, Code, Message, Data} when is_integer(Code), is_binary(Message) ->
             %% Custom error, with data
             make_error_response(Code, Message, Data, Id);
-        Class:Error ->
+        Class:Error:Stacktrace ->
             error_logger:error_msg(
                 "Error in JSON-RPC handler for method ~s with params ~p (id: ~p): ~p:~p from ~p",
-                [Method, Params, Id, Class, Error, erlang:get_stacktrace()]),
+                [Method, Params, Id, Class, Error, Stacktrace]),
             make_standard_error_response(internal_error, Id)
     end;
 dispatch(_, _HandlerFun) ->


### PR DESCRIPTION
…n and add test for generic runtime error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for runtime errors, ensuring more accurate error reporting in responses.

* **Tests**
  * Added a new test to verify correct handling and reporting of generic runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->