### PR TITLE
support map-based JSON objects and update jsone tests

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,7 @@
     {test, [
         {deps, [
             {jsone, {git, "https://github.com/sile/jsone.git", {tag, "1.9.0"}}}
+          , {jiffy, {git, "https://github.com/davisp/jiffy.git", {tag, "1.1.2"}}}
         ]}
     ]}
 ]}.

--- a/test/jsonrpc2_jiffy_test.erl
+++ b/test/jsonrpc2_jiffy_test.erl
@@ -1,0 +1,54 @@
+-module(jsonrpc2_jiffy_test).
+
+%% A couple of simple integration tests that exercise jsonrpc2 with the
+%% "jiffy" JSON library instead of the term_to_binary/binary_to_term stub used
+%% elsewhere in the suite.  We only want to prove that jsonrpc2 can work with
+%% a real JSON encoder/decoder that follows the eep0018 representation.
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% ------------------------------------------------------------------
+%% Helper wrappers so that the tests mirror existing ones --------------
+%% ------------------------------------------------------------------
+
+encode(Term) -> jiffy:encode(Term).
+decode(Bin)  -> jiffy:decode(Bin).
+
+good_handler(_Method, _Params) -> ok.
+
+%% ------------------------------------------------------------------
+%% 1. Ensure notifications encoded with jiffy are handled without reply.
+%% ------------------------------------------------------------------
+
+handle_notification_jiffy_test() ->
+    Notification = {[{<<"jsonrpc">>, <<"2.0">>},
+                     {<<"method">>, <<"notify">>},
+                     {<<"params">>, []}]},
+    Encoded = encode(Notification),
+    noreply = jsonrpc2:handle(Encoded,
+                              fun good_handler/2,
+                              fun decode/1,
+                              fun encode/1).
+
+%% ------------------------------------------------------------------
+%% 2. Round-trip a normal call using jiffy encode/decode.
+%% ------------------------------------------------------------------
+
+echo_handler(_Method, _Params) -> <<"pong">>.
+
+handle_call_jiffy_test() ->
+    Call = {[{<<"jsonrpc">>, <<"2.0">>},
+             {<<"method">>, <<"ping">>},
+             {<<"params">>, []},
+             {<<"id">>, 1}]},
+    EncodedCall = encode(Call),
+
+    {reply, EncodedReply} = jsonrpc2:handle(EncodedCall,
+                                            fun echo_handler/2,
+                                            fun decode/1,
+                                            fun encode/1),
+
+    %% Decode the reply using jiffy and validate its structure.
+    {[{<<"jsonrpc">>, <<"2.0">>},
+       {<<"result">>, <<"pong">>},
+       {<<"id">>, 1}]} = decode(EncodedReply).

--- a/test/jsonrpc2_jsone_test.erl
+++ b/test/jsonrpc2_jsone_test.erl
@@ -1,0 +1,54 @@
+-module(jsonrpc2_jsone_test).
+
+%% A couple of simple integration tests that exercise jsonrpc2 with the
+%% "jsone" JSON library instead of the term_to_binary/binary_to_term stub used
+%% elsewhere in the suite.  We only want to prove that jsonrpc2 can work with
+%% a real JSON encoder/decoder that follows the eep0018 representation.
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% ------------------------------------------------------------------
+%% Helper wrappers so that the tests mirror existing ones --------------
+%% ------------------------------------------------------------------
+
+encode(Term) -> jsone:encode(Term).
+decode(Bin)  -> jsone:decode(Bin).
+
+good_handler(_Method, _Params) -> ok.
+
+%% ------------------------------------------------------------------
+%% 1. Ensure notifications encoded with jsone are handled without reply.
+%% ------------------------------------------------------------------
+
+handle_notification_jsone_test() ->
+    Notification = {[{<<"jsonrpc">>, <<"2.0">>},
+                     {<<"method">>, <<"notify">>},
+                     {<<"params">>, []}]},
+    Encoded = encode(Notification),
+    noreply = jsonrpc2:handle(Encoded,
+                              fun good_handler/2,
+                              fun decode/1,
+                              fun encode/1).
+
+%% ------------------------------------------------------------------
+%% 2. Round-trip a normal call using jsone encode/decode.
+%% ------------------------------------------------------------------
+
+echo_handler(_Method, _Params) -> <<"pong">>.
+
+handle_call_jsone_test() ->
+    Call = {[{<<"jsonrpc">>, <<"2.0">>},
+             {<<"method">>, <<"ping">>},
+             {<<"params">>, []},
+             {<<"id">>, 1}]},
+    EncodedCall = encode(Call),
+
+    {reply, EncodedReply} = jsonrpc2:handle(EncodedCall,
+                                            fun echo_handler/2,
+                                            fun decode/1,
+                                            fun encode/1),
+
+    %% Decode the reply using jsone and validate its structure.
+    {[{<<"jsonrpc">>, <<"2.0">>},
+       {<<"result">>, <<"pong">>},
+       {<<"id">>, 1}]} = decode(EncodedReply).

--- a/test/jsonrpc2_jsone_test.erl
+++ b/test/jsonrpc2_jsone_test.erl
@@ -21,9 +21,9 @@ good_handler(_Method, _Params) -> ok.
 %% ------------------------------------------------------------------
 
 handle_notification_jsone_test() ->
-    Notification = {[{<<"jsonrpc">>, <<"2.0">>},
-                     {<<"method">>, <<"notify">>},
-                     {<<"params">>, []}]},
+    Notification = #{<<"jsonrpc">> => <<"2.0">>,
+                     <<"method">> => <<"notify">>,
+                     <<"params">> => []},
     Encoded = encode(Notification),
     noreply = jsonrpc2:handle(Encoded,
                               fun good_handler/2,
@@ -37,10 +37,10 @@ handle_notification_jsone_test() ->
 echo_handler(_Method, _Params) -> <<"pong">>.
 
 handle_call_jsone_test() ->
-    Call = {[{<<"jsonrpc">>, <<"2.0">>},
-             {<<"method">>, <<"ping">>},
-             {<<"params">>, []},
-             {<<"id">>, 1}]},
+    Call = #{<<"jsonrpc">> => <<"2.0">>,
+             <<"method">> => <<"ping">>,
+             <<"params">> => [],
+             <<"id">> => 1},
     EncodedCall = encode(Call),
 
     {reply, EncodedReply} = jsonrpc2:handle(EncodedCall,
@@ -49,6 +49,6 @@ handle_call_jsone_test() ->
                                             fun encode/1),
 
     %% Decode the reply using jsone and validate its structure.
-    {[{<<"jsonrpc">>, <<"2.0">>},
-       {<<"result">>, <<"pong">>},
-       {<<"id">>, 1}]} = decode(EncodedReply).
+    #{<<"jsonrpc">> := <<"2.0">>,
+       <<"result">> := <<"pong">>,
+       <<"id">> := 1} = decode(EncodedReply).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for JSON-RPC request objects represented as maps.
  
* **Tests**
  * Added integration tests to verify compatibility with both `jiffy` and `jsone` JSON libraries.
  * Ensured correct handling of JSON-RPC notifications and calls using real JSON encoders/decoders.

* **Chores**
  * Added `jiffy` as a test dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->